### PR TITLE
Fix page not found gitscrum-community link.

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -19,7 +19,7 @@
 
                 <h3 class="">
                     {{trans('gitscrum.welcome-to')}}
-                    <a href="https://github.com/gitscrum-community-edition" target="_blank"><strong>GitScrum</strong></a>
+                    <a href="https://github.com/gitscrum-community" target="_blank"><strong>GitScrum</strong></a>
                 </h3>
 
                 <a href="{{route('auth.provider', ['provider' => 'github'])}}" class="btn btn-lg btn-default btn-loader">


### PR DESCRIPTION
## Description
This pull request fix the page not found message when user click on the link to [gitscrum-community](https://github.com/gitscrum-community) in login page.

## Motivation and context
I'm getting page not found when I click on the link to [gitscrum-community](https://github.com/gitscrum-community) in login page.

## How has this been tested?

I tested this change by clicking on the link, because I don't find laravel dusk dependency for browser testing, but now it works properly.

## Screenshots 

![gitscrum-auth-login](https://user-images.githubusercontent.com/33736985/45837104-d1b08b00-bd0e-11e8-940e-51b0acb2f701.jpg)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes. 
- [x] If my change requires a change to the documentation, I have updated it accordingly.
